### PR TITLE
feat: デフォルトで現在のリポジトリのセッションのみ読み込むよう変更

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,9 +13,9 @@ const packageJson = JSON.parse(
 );
 
 const program = new Command();
-const configManager = new ConfigManager();
+const configManager = ConfigManager.createForRepository();
 const config = configManager.loadConfig();
-const agentManager = new AgentManager(config);
+const agentManager = AgentManager.createForRepository(config);
 
 program
   .name('claude-worktree')


### PR DESCRIPTION
- CLIでConfigManager.createForRepository()を使用
- CLIでAgentManager.createForRepository()を使用
- 現在のリポジトリのセッションのみが表示されるように
- Git外ディレクトリではグローバル設定にフォールバック

🤖 Generated with [Claude Code](https://claude.ai/code)